### PR TITLE
Git - Add File - 'utf8' codec can't decode byte in position 0: invalid start byte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.swp
+.vs
+.vs/

--- a/git_connector.py
+++ b/git_connector.py
@@ -252,7 +252,7 @@ class GitConnector(BaseConnector):
 
                 try:
                     vault_file_path = Path(list(vault_file_info)[0].get('path'))
-                    vault_file_data = vault_file_path.read_text()
+                    vault_file_data = vault_file_path.read_bytes()
                 except Exception as e:
                     self.debug_print(f'Exception : {e}')
                     return action_result.set_status(phantom.APP_ERROR)
@@ -268,7 +268,7 @@ class GitConnector(BaseConnector):
             full_path.parent.mkdir(parents=True, exist_ok=True)
 
             # overwrite file into local disk
-            full_path.write_text(file_data)
+            full_path.write_bytes(file_data)
 
             # add into index
             repo.index.add(file_path)


### PR DESCRIPTION
ame of the app
[git](https://github.com/splunk-soar-connectors/git/)

Describe the bug
When attempting to use add file to add a file to the repository files that cannot be read into 'utf8' are failing with the expectation "'utf8' codec can't decode byte 0xa5 in position 0: invalid start byte" as an example.

To Reproduce
Steps to reproduce the behavior:

Create Event/Container with a .xlsm file type as a vault artifact
Use Clone repo to bring done repo
Use Add File to move file to repo from vault location
See error
Expected behavior
It appears files that cannot be read are failing with 'utf8' are failing with the expectation "'utf8' codec can't decode byte 0xa5 in position 0: invalid start byte" as an example.

Splunk SOAR Version (please complete the following information):

Unprivileged Install - SOAR 5.5
OS Version - RHEL 8.7
App Version - GIT 2.1.0
Additional context
Modify git_connector.py
changing read_text() to read_bytes() seems to work
255 vault_file_data = vault_file_path.read_text() > vault_file_data = vault_file_path.read_bytes()
271 full_path.write_text(file_data) > full_path.write_bytes(file_data)

I am no expert and not sure what implications this has but this is a viable solution for our instance.