### PR TITLE
Update python_version 3.13 phase 5

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/git.json
+++ b/git.json
@@ -25,7 +25,7 @@
     "product_version_regex": ".*",
     "min_phantom_version": "6.3.0",
     "fips_compliant": true,
-    "python_version": "3.9",
+    "python_version": "3.9, 3.13",
     "logo": "logo_git.svg",
     "logo_dark": "logo_git_dark.svg",
     "latest_tested_versions": [

--- a/git_connector.py
+++ b/git_connector.py
@@ -22,14 +22,14 @@ import urllib.parse
 from pathlib import Path
 from shutil import rmtree
 
+import git
+
 # Phantom imports
 import phantom.app as phantom
 import phantom.rules as phantom_rules
 from Cryptodome.PublicKey import RSA
 from phantom.action_result import ActionResult
 from phantom.base_connector import BaseConnector
-
-import git
 
 # Local imports
 import git_consts as consts

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 5 part 2

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase5-part2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase5-part2)